### PR TITLE
feat: add ClickUp description update, PR URL field, and error recording to agent.yml

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -123,7 +123,7 @@ jobs:
           FIELD_ID: ${{ secrets.CLICKUP_PR_URL_FIELD_ID }}
           CODE_RESULT: ${{ steps.claude_code.outputs.result }}
         run: |
-          PR_URL=$(echo "$CODE_RESULT" | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -1 || true)
+          PR_URL=$(echo "$CODE_RESULT" | grep -oE 'https://github\.com/[^[:space:])\]>,]+/pull/[0-9]+' | head -1 || true)
           if [ -n "$PR_URL" ]; then
             curl -fsS --retry 3 --retry-delay 2 --retry-all-errors \
               -X POST "https://api.clickup.com/api/v2/task/${TASK_ID}/field/${FIELD_ID}" \


### PR DESCRIPTION
## Summary
- SPEC フェーズ完了時に Claude Code の出力（仕様書）を ClickUp タスクの Description に書き戻すステップを追加
- CODE フェーズ完了時に PR URL を ClickUp の GitHub PR URL カスタムフィールドに設定するステップを追加
- エラー発生時に GitHub Actions Run URL を Agent Error カスタムフィールドに記録するステップを追加
- 必要な新規 Secrets: `CLICKUP_PR_URL_FIELD_ID`, `CLICKUP_AGENT_ERROR_FIELD_ID`

## Test Plan
- [x] `go test ./...` がパスする
- [x] `go vet ./...` がパスする
- [ ] SPEC フェーズ実行後、ClickUp タスクの Description が仕様書で更新されることを確認
- [ ] CODE フェーズ実行後、ClickUp タスクの PR URL カスタムフィールドに PR リンクが設定されることを確認
- [ ] エラー発生時、Agent Error カスタムフィールドに Actions Run URL が記録されることを確認

Closes #3
Closes #4