### PR TITLE
fix: リトライ jitter 追加と reconcile GetTask タイムアウト設定

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -431,7 +431,7 @@ func calcRetryDelay(attempt int) time.Duration {
 // 結果は retryMaxDelayMS でクリップされる。
 func addJitter(base time.Duration) time.Duration {
 	// [0.75, 1.25) の範囲でスケーリング
-	factor := 0.75 + rand.Float64()*0.5
+	factor := 0.75 + rand.Float64()*0.5 //nolint:gosec // G404: jitter 用途であり暗号論的安全性は不要
 	result := time.Duration(float64(base) * factor)
 	if max := time.Duration(retryMaxDelayMS) * time.Millisecond; result > max {
 		return max

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -428,10 +428,15 @@ func calcRetryDelay(attempt int) time.Duration {
 
 // addJitter はベース遅延に ±25% のランダム jitter を加える。
 // thundering herd を防ぐため、複数タスクのリトライタイミングを分散させる。
+// 結果は retryMaxDelayMS でクリップされる。
 func addJitter(base time.Duration) time.Duration {
 	// [0.75, 1.25) の範囲でスケーリング
 	factor := 0.75 + rand.Float64()*0.5
-	return time.Duration(float64(base) * factor)
+	result := time.Duration(float64(base) * factor)
+	if max := time.Duration(retryMaxDelayMS) * time.Millisecond; result > max {
+		return max
+	}
+	return result
 }
 
 // scheduleRetry はリトライタイマーを設定する

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -268,7 +269,9 @@ const (
 func (o *Orchestrator) reconcile(ctx context.Context) {
 	runningIDs := o.state.RunningTaskIDs()
 	for _, taskID := range runningIDs {
-		task, err := o.taskClient.GetTask(ctx, taskID)
+		getCtx, cancel := context.WithTimeout(ctx, reconcileGetTaskTimeout)
+		task, err := o.taskClient.GetTask(getCtx, taskID)
+		cancel()
 		if err != nil {
 			o.logger.Warn("failed to get task for reconciliation, skipping", "task_id", taskID, "error", err)
 			continue
@@ -406,9 +409,11 @@ const (
 	retryMaxDelayMS = 300000
 	// retryMaxExponent はビットシフトオーバーフロー防止のための最大指数
 	retryMaxExponent = 5 // 2^5 = 32 → 10000 * 32 = 320000 → capped to 300000
+	// reconcileGetTaskTimeout は reconcile 内の個別 GetTask 呼び出しのタイムアウト
+	reconcileGetTaskTimeout = 10 * time.Second
 )
 
-// calcRetryDelay はリトライのバックオフ遅延を計算する
+// calcRetryDelay はリトライのベース遅延を計算する（決定論的）
 func calcRetryDelay(attempt int) time.Duration {
 	exp := attempt - 1
 	if exp > retryMaxExponent {
@@ -421,6 +426,14 @@ func calcRetryDelay(attempt int) time.Duration {
 	return time.Duration(delay) * time.Millisecond
 }
 
+// addJitter はベース遅延に ±25% のランダム jitter を加える。
+// thundering herd を防ぐため、複数タスクのリトライタイミングを分散させる。
+func addJitter(base time.Duration) time.Duration {
+	// [0.75, 1.25) の範囲でスケーリング
+	factor := 0.75 + rand.Float64()*0.5
+	return time.Duration(float64(base) * factor)
+}
+
 // scheduleRetry はリトライタイマーを設定する
 func (o *Orchestrator) scheduleRetry(taskID string, phase string, attempt int, err error) {
 	o.retryMu.Lock()
@@ -430,7 +443,7 @@ func (o *Orchestrator) scheduleRetry(taskID string, phase string, attempt int, e
 		return
 	}
 
-	delayDuration := calcRetryDelay(attempt)
+	delayDuration := addJitter(calcRetryDelay(attempt))
 
 	tl := logging.TaskLogger(o.logger, taskID, phase)
 	tl.Warn("scheduling retry", "attempt", attempt, "delay", delayDuration, "error", err)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -744,6 +744,15 @@ func TestAddJitter(t *testing.T) {
 	if len(results) < 2 {
 		t.Error("addJitter returned the same value for all 10 calls, expected variance")
 	}
+
+	// retryMaxDelayMS を超えないことを確認
+	maxDelay := time.Duration(retryMaxDelayMS) * time.Millisecond
+	for range 100 {
+		got := addJitter(maxDelay)
+		if got > maxDelay {
+			t.Errorf("addJitter(%v) = %v, exceeds max %v", maxDelay, got, maxDelay)
+		}
+	}
 }
 
 func TestHandleRetry(t *testing.T) {
@@ -931,7 +940,7 @@ func TestReconcile_GetTaskTimeout(t *testing.T) {
 		mockTaskClient: mockTaskClient{
 			taskMap: map[string]*clickup.Task{},
 		},
-		hangDuration: 30 * time.Second, // reconcileGetTaskTimeout (10s) より長い
+		hangDuration: 11 * time.Second, // reconcileGetTaskTimeout (10s) より長い
 	}
 	dispatcher := &mockWorkflowDispatcher{}
 	o := New(slowClient, dispatcher, Config{PollInterval: time.Second, StatusMapping: sm}, defaultLogger, nil, "", nil)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -724,6 +724,28 @@ func TestCalcRetryDelay(t *testing.T) {
 	}
 }
 
+func TestAddJitter(t *testing.T) {
+	base := 10 * time.Second
+	minExpected := time.Duration(float64(base) * 0.75)
+	maxExpected := time.Duration(float64(base) * 1.25)
+
+	for range 100 {
+		got := addJitter(base)
+		if got < minExpected || got >= maxExpected {
+			t.Errorf("addJitter(%v) = %v, want in [%v, %v)", base, got, minExpected, maxExpected)
+		}
+	}
+
+	// 全く同じ値にならないことで jitter が機能していることを確認
+	results := make(map[time.Duration]struct{})
+	for range 10 {
+		results[addJitter(base)] = struct{}{}
+	}
+	if len(results) < 2 {
+		t.Error("addJitter returned the same value for all 10 calls, expected variance")
+	}
+}
+
 func TestHandleRetry(t *testing.T) {
 	sm := defaultSM
 	tests := []struct {
@@ -899,6 +921,36 @@ func TestReconcile_LimiterRelease(t *testing.T) {
 				t.Errorf("limiter active = %d, wantLimiterKept = %v", limiter.ActiveCount(), tt.wantLimiterKept)
 			}
 		})
+	}
+}
+
+func TestReconcile_GetTaskTimeout(t *testing.T) {
+	sm := defaultSM
+	// GetTask が長時間ハングするモック
+	slowClient := &hangingTaskClient{
+		mockTaskClient: mockTaskClient{
+			taskMap: map[string]*clickup.Task{},
+		},
+		hangDuration: 30 * time.Second, // reconcileGetTaskTimeout (10s) より長い
+	}
+	dispatcher := &mockWorkflowDispatcher{}
+	o := New(slowClient, dispatcher, Config{PollInterval: time.Second, StatusMapping: sm}, defaultLogger, nil, "", nil)
+
+	o.state.Claim("task-1")
+	o.state.MarkRunning("task-1")
+
+	start := time.Now()
+	o.reconcile(context.Background())
+	elapsed := time.Since(start)
+
+	// タイムアウトにより 30s 待たずに完了すること
+	if elapsed > 15*time.Second {
+		t.Errorf("reconcile took %v, expected to timeout around %v", elapsed, reconcileGetTaskTimeout)
+	}
+
+	// タイムアウトエラーのためタスクはスキップされて維持される
+	if !o.state.IsClaimedOrRunning("task-1") {
+		t.Fatal("expected task-1 to remain running on GetTask timeout")
 	}
 }
 
@@ -1207,6 +1259,21 @@ func TestRecoverProcessingTasks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// hangingTaskClient は GetTask が指定時間ハングするモック
+type hangingTaskClient struct {
+	mockTaskClient
+	hangDuration time.Duration
+}
+
+func (h *hangingTaskClient) GetTask(ctx context.Context, taskID string) (*clickup.Task, error) {
+	select {
+	case <-time.After(h.hangDuration):
+		return h.mockTaskClient.GetTask(ctx, taskID)
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 


### PR DESCRIPTION
## 概要
オーケストレーターのリトライとリコンシリエーション処理の耐障害性を改善する。

## 変更内容
- リトライバックオフに ±25% のランダム jitter を追加し、複数タスク同時リトライ時の thundering herd を防止
- reconcile 内の各 `GetTask` 呼び出しに 10 秒のタイムアウトを設定し、1 つの API ハングで全ポーリングがブロックされる問題を解消

## テスト
- [x] `TestAddJitter` — jitter が [0.75, 1.25) の範囲に収まること、値にばらつきがあること
- [x] `TestReconcile_GetTaskTimeout` — API ハング時にタイムアウトで打ち切られ、タスク状態が維持されること
- [x] 既存テスト全パス (`go test ./...`)